### PR TITLE
decouple serializing/logging json to make it easier to inject datadog traces

### DIFF
--- a/lib/job.ts
+++ b/lib/job.ts
@@ -113,10 +113,15 @@ export class Job {
 		if (this.jobba.config?.logFormat === 'console') {
 			console[log.level](levelText, hash, ...log.values);
 		} else if (this.jobba.config?.logFormat === 'json') {
-			console[log.level](JSON.stringify({ levelText, hash, values: log.values }));
+			this.serializeMsg(log.level, { levelText, hash, values: log.values });
 		}
 		this.data.logs.push(log);
 		await this.save();
+	}
+
+	public serializeMsg(level: string, data: Object) {
+		const json = JSON.stringify(data);
+		console[level](json);
 	}
 
 	public debug(...values: Array<any>) { return this.logger('debug', ...values); }


### PR DESCRIPTION
This PR allows users of this module to patch the method that is responsible for serializing an object and logging it.  The primary driver is so APM tools(like datadog) can be used to inject traces so logs are associated in datadog: see https://docs.datadoghq.com/tracing/connect_logs_and_traces/nodejs/